### PR TITLE
Switch to Travis CI's xenial distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
+dist: xenial
 language: python
 python:
     - 2.7
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
     - nightly
     - pypy
     - pypy3
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
 script:
   - python setup.py flake8
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ python:
     - 3.5
     - 3.6
     - 3.7
-    - nightly
-    - pypy
-    - pypy3
+    - pypy2.7
+    - pypy3.5
 script:
   - python setup.py flake8
   - python setup.py test


### PR DESCRIPTION
This gives us built-in support for Python 3.7.