### PR TITLE
Detect and warn on assertTrue misuse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,8 @@ the generic methods.
 +------------------------------------------+-----------------------------------+------+
 | ``assertNotAlmostEquals(a, b, x)``       | ``assertNotAlmostEqual(a, b, x)`` | A503 |
 +------------------------------------------+-----------------------------------+------+
+| ``assertTrue(a, b)``                     | ``assertTrue(a, msg=b)``          | A503 |
++------------------------------------------+-----------------------------------+------+
 
 Note that some suggestions are normalized forms of the original, such as when
 a double-negative is used (``assertFalse(a != b)`` → ``assertEqual(a, b)``).
@@ -113,6 +115,7 @@ This extension adds three new `error codes`__ (using the ``A50`` prefix):
 - ``A501``: prefer *{func}* for '*{op}*' expressions
 - ``A502``: prefer *{func}* instead of comparing to *{obj}*
 - ``A503``: use *{func}* instead of the deprecated *{name}*
+- ``A504``: prefer the 'msg=' kwarg for *{func}* diagnostics
 
 .. __: https://flake8.pycqa.org/en/latest/user/error-codes.html
 

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,8 @@ the generic methods.
 +------------------------------------------+-----------------------------------+------+
 | ``assertTrue(a, b)``                     | ``assertTrue(a, msg=b)``          | A504 |
 +------------------------------------------+-----------------------------------+------+
+| ``assertFalse(a, b)``                    | ``assertFalse(a, msg=b)``         | A504 |
++------------------------------------------+-----------------------------------+------+
 
 Note that some suggestions are normalized forms of the original, such as when
 a double-negative is used (``assertFalse(a != b)`` → ``assertEqual(a, b)``).

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ the generic methods.
 +------------------------------------------+-----------------------------------+------+
 | ``assertNotAlmostEquals(a, b, x)``       | ``assertNotAlmostEqual(a, b, x)`` | A503 |
 +------------------------------------------+-----------------------------------+------+
-| ``assertTrue(a, b)``                     | ``assertTrue(a, msg=b)``          | A503 |
+| ``assertTrue(a, b)``                     | ``assertTrue(a, msg=b)``          | A504 |
 +------------------------------------------+-----------------------------------+------+
 
 Note that some suggestions are normalized forms of the original, such as when

--- a/flake8_assertive.py
+++ b/flake8_assertive.py
@@ -83,6 +83,7 @@ class Checker(object):
     A501 = "prefer {func}() for '{op}' expressions"
     A502 = "prefer {func}() instead of comparing to {obj}"
     A503 = "use {func}() instead of the deprecated {name}()"
+    A504 = "prefer the 'msg=' kwarg for {func}() diagnostics"
 
     def __init__(self, tree, filename):
         self.tree = tree
@@ -164,6 +165,8 @@ class Checker(object):
                              op='round')
 
     def check_asserttrue(self, node):
+        if len(node.args) > 1:
+            yield self.error(node, 'A504', 'assertTrue')
         arg = next(args(node), None)
         if arg and isinstance(arg, ast.Compare) and len(arg.ops) == 1:
             op = arg.ops[0]

--- a/flake8_assertive.py
+++ b/flake8_assertive.py
@@ -201,6 +201,8 @@ class Checker(object):
                 node, 'A501', 'assertIsInstance', op='isinstance()')
 
     def check_assertfalse(self, node):
+        if len(node.args) > 1:
+            yield self.error(node, 'A504', 'assertFalse')
         arg = next(args(node), None)
         if arg and isinstance(arg, ast.Compare) and len(arg.ops) == 1:
             op = arg.ops[0]

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -173,3 +173,7 @@ class TestChecks(unittest.TestCase):
     def test_deprecated(self):
         self.check("self.assertEquals(True, a)", "A502", "assertTrue()")
         self.check("self.assertEquals(a, b)", "A503", "assertEqual()")
+
+    def test_asserttrue_misuse(self):
+        self.check("self.assertTrue(a, 'foo')", expected="A504")
+        self.check("self.assertTrue(a, msg='foo')", expected=None)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -177,3 +177,7 @@ class TestChecks(unittest.TestCase):
     def test_asserttrue_misuse(self):
         self.check("self.assertTrue(a, 'foo')", expected="A504")
         self.check("self.assertTrue(a, msg='foo')", expected=None)
+
+    def test_assertfalse_misuse(self):
+        self.check("self.assertFalse(a, 'foo')", expected="A504")
+        self.check("self.assertFalse(a, msg='foo')", expected=None)


### PR DESCRIPTION
A common error is to use the two argument form of `assertTrue()` when
one intends to use `assertEqual()`. This leads to meaningless tests that
(almost) always pass.

For example:

```
self.assertTrue(might_be_foo, "foo")
```

instead of:

```
self.assertEqual(might_be_foo, "foo")
```

The second argument is the error message on failure, and is better
specified as the `msg=` kerword argument.

This was inspired by https://richardtier.com/2022/02/16/3-of-666-python-codebases-we-checked-had-silently-failing-unit-tests-and-we-fixed-them-all%ef%bf%bc/