### PR TITLE
Drop support for Python 3.8 and add 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', 'pypy-3.8']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.9']
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,11 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Software Development :: Quality Assurance
     Topic :: Software Development :: Testing
@@ -31,7 +31,7 @@ classifiers =
 
 [options]
 py_modules = flake8_assertive
-python_requires = >= 3.8.1
+python_requires = >= 3.9
 zip_safe = True
 
 [options.entry_points]


### PR DESCRIPTION
Python 3.8 has reached its end-of-life.